### PR TITLE
feat(k3s-install-pinned):k3sインストール及びバージョン固定

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -60,6 +60,13 @@ resource "aws_instance" "k3s" {
   vpc_security_group_ids      = [aws_security_group.ec2_k3s.id]
   associate_public_ip_address = true
 
+  user_data = templatefile("${path.module}/user_data/install_k3s.sh.tftpl", {
+    k3s_version         = var.k3s_version
+    k3s_disable_traefik = var.k3s_disable_traefik
+  })
+
+  user_data_replace_on_change = true
+
   tags = {
     Name = "${var.name_prefix}-k3s"
   }

--- a/terraform/user_data/install_k3s.sh.tftpl
+++ b/terraform/user_data/install_k3s.sh.tftpl
@@ -1,9 +1,40 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export INSTALL_K3S_VERSION="${k3s_version}"
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
-curl -sfL https://get.k3s.io | sh -s - server --write-kubeconfig-mode 644
+echo "[user-data] start"
 
-apt-get update -y
-apt-get install -y jq
+K3S_VERSION="${k3s_version}"
+
+# Fetch public IPv4 via IMDSv2
+TOKEN="$(curl -fsS -X PUT "http://169.254.169.254/latest/api/token" \
+  -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")"
+
+PUBLIC_IP="$(curl -fsS -H "X-aws-ec2-metadata-token: $TOKEN" \
+  "http://169.254.169.254/latest/meta-data/public-ipv4")"
+
+LOCAL_IP="$(curl -fsS -H "X-aws-ec2-metadata-token: $TOKEN" \
+  "http://169.254.169.254/latest/meta-data/local-ipv4")"
+
+echo "[user-data] public_ip=$PUBLIC_IP local_ip=$LOCAL_IP version=$K3S_VERSION"
+
+export INSTALL_K3S_VERSION="$K3S_VERSION"
+
+K3S_EXTRA_ARGS="server \
+  --tls-san $PUBLIC_IP \
+  --node-external-ip $PUBLIC_IP \
+  --node-ip $LOCAL_IP \
+  --write-kubeconfig-mode 600"
+
+%{ if k3s_disable_traefik ~}
+K3S_EXTRA_ARGS="$K3S_EXTRA_ARGS --disable traefik"
+%{ endif ~}
+
+curl -sfL https://get.k3s.io | sh -s - $K3S_EXTRA_ARGS
+
+echo "[user-data] k3s installed"
+systemctl enable k3s
+systemctl restart k3s
+
+echo "[user-data] done"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -55,5 +55,15 @@ variable "subnet_id" {
 
 variable "k3s_version" {
   type        = string
-  description = "Pinned k3s version (e.g. v1.29.8+k3s1)"
+  description = "Pinned k3s version (e.g. v1.29.6+k3s1)"
+  validation {
+    condition     = can(regex("^v\\d+\\.\\d+\\.\\d+\\+k3s\\d+$", var.k3s_version))
+    error_message = "k3s_version must look like:v1.29.6+k3s1"
+  }
+}
+
+variable "k3s_disable_traefik" {
+  type        = bool
+  description = "Disable bundled Traefik ingress controller"
+  default     = true
 }


### PR DESCRIPTION
## 概要
- EC2の`user_data`でk3sをインストールし、`k3s_version`でバージョン固定できるようにしました。また、Public IP を IMDSv2から取得して`--tls-san` と `--node-external-ip`に設定し、外部(ローカル)からのkubectl接続に向けた証明書/ノード情報を整備しました。

## 変更内容
- `aws_instance.k3s` に `user_data = templatefile(...)` を追加（変更時は置き換え）
- `k3s_version` 変数を追加し、固定バージョンでインストール
- IMDSv2 で Public/Local IP を取得して以下を設定
  - `--tls-san <public-ip>`
  - `--node-external-ip <public-ip>`
  - `--node-ip <local-ip>`
- kubeconfig 権限を `--write-kubeconfig-mode 600` に設定
- （任意）Traefik を無効化できるオプションを追加（デフォルト無効）

## 動作確認
- `terraform plan/apply` が成功（`-var-file=envs/dev/terraform.tfvars` を使用）
- EC2 上で確認
  - `sudo k3s --version` で固定バージョンを確認

```bash
ubuntu@ip-172-31-14-242:~$ sudo tail -n 200 /var/log/user-data.log
[user-data] start
[user-data] public_ip= local_ip=172.31.14.242 version=v1.29.6+k3s1
[INFO]  Using v1.29.6+k3s1 as release
[INFO]  Downloading hash https://github.com/k3s-io/k3s/releases/download/v1.29.6+k3s1/sha256sum-amd64.txt
[INFO]  Downloading binary https://github.com/k3s-io/k3s/releases/download/v1.29.6+k3s1/k3s
[INFO]  Verifying binary download
[INFO]  Installing k3s to /usr/local/bin/k3s
[INFO]  Skipping installation of SELinux RPM
[INFO]  Creating /usr/local/bin/kubectl symlink to k3s
[INFO]  Creating /usr/local/bin/crictl symlink to k3s
[INFO]  Creating /usr/local/bin/ctr symlink to k3s
[INFO]  Creating killall script /usr/local/bin/k3s-killall.sh
[INFO]  Creating uninstall script /usr/local/bin/k3s-uninstall.sh
[INFO]  env: Creating environment file /etc/systemd/system/k3s.service.env
[INFO]  systemd: Creating service file /etc/systemd/system/k3s.service
[INFO]  systemd: Enabling k3s unit
Created symlink /etc/systemd/system/multi-user.target.wants/k3s.service → /etc/systemd/system/k3s.service.
[INFO]  systemd: Starting k3s
[user-data] k3s installed
[user-data] done
ubuntu@ip-172-31-14-242:~$ sudo k3s --version
k3s version v1.29.6+k3s1 (83ae095a)
go version go1.21.11
ubuntu@ip-172-31-14-242:~$ sudo k3s kubectl get nodes -o wide
NAME               STATUS   ROLES                  AGE     VERSION        INTERNAL-IP     EXTERNAL-IP     OS-IMAGE             KERNEL-VERSION   CONTAINER-RUNTIME
ip-172-31-14-242   Ready    control-plane,master   4m11s   v1.29.6+k3s1   172.31.14.242     Ubuntu 22.04.5 LTS   6.8.0-1044-aws   containerd://1.7.17-k3s1
```
## 関連
* Close #3
